### PR TITLE
feature: re-translate constraint violation messages when originated from Validation::createCallable()

### DIFF
--- a/src/ExceptionalMatcher/Integration/Validator/Formatter/Embedded/Tests/EmbeddedViolationListFormatterUnitTest.php
+++ b/src/ExceptionalMatcher/Integration/Validator/Formatter/Embedded/Tests/EmbeddedViolationListFormatterUnitTest.php
@@ -13,10 +13,15 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Symfony\Component\Validator\Exception\ValidationFailedException;
 use Symfony\Component\Validator\Validation;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Throwable;
 
+use function array_diff_key;
 use function array_flip;
-use function array_intersect_key;
+use function sprintf;
+use function strtr;
 
 /**
  * @covers \PhPhD\ExceptionalMatcher\Integration\Validator\Formatter\Embedded\ViolationsEmbeddedExceptionFormatter
@@ -37,6 +42,17 @@ final class EmbeddedViolationListFormatterUnitTest extends TestCase
             'kernel.build_dir' => __DIR__.'/var',
         ]);
 
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')
+            ->willReturnCallback(static fn (
+                string $id,
+                array $params,
+                string $domain,
+            ): string => sprintf('re-translated [%s]: %s ', $domain, strtr($id, $params)))
+        ;
+        $container->set('translator', $translator);
+        $container->setParameter('validator.translation_domain', 'domain');
+
         $container->compile();
 
         /** @var ExceptionMatcher<ConstraintViolationListInterface> $matcher */
@@ -44,20 +60,16 @@ final class EmbeddedViolationListFormatterUnitTest extends TestCase
         $this->matcher = $matcher;
     }
 
-    public function testViolationsEmbeddedExceptionMapping(): void
+    public function testViolationsEmbeddedExceptionProvidesViolationsList(): void
     {
-        $violationList = Validation::createValidator()->validate('123', [$constraint = new Length(max: 2)]);
-
         $message = HandleableMessageStub::create()->withNestedObject(new NestedHandleableMessage());
+
+        $violationList = Validation::createValidator()->validate('123', [$constraint = new Length(max: 2)]);
         $originalException = new ViolationsEmbeddedExampleException($violationList);
 
-        $violationList = $this->matcher->match($originalException, $message);
+        $violation = $this->matchOne($originalException, $message);
 
-        self::assertNotNull($violationList);
-        self::assertCount(1, $violationList);
-
-        $violation = $violationList[0];
-        self::assertInstanceOf(ConstraintViolation::class, $violation);
+        // Pre-translated message is kept as-is: a ViolationsEmbeddedException is not re-translated.
         self::assertSame(
             'This value is too long. It should have 2 characters or less.',
             $violation->getMessage(),
@@ -66,15 +78,12 @@ final class EmbeddedViolationListFormatterUnitTest extends TestCase
             'This value is too long. It should have {{ limit }} character or less.|This value is too long. It should have {{ limit }} characters or less.',
             $violation->getMessageTemplate(),
         );
-
-        $parameters = array_intersect_key(
-            $violation->getParameters(),
-            array_flip(['{{ value }}', '{{ limit }}']),
-        );
         self::assertSame([
             '{{ value }}' => '"123"',
             '{{ limit }}' => '2',
-        ], $parameters);
+            '{{ value_length }}' => '3',
+            // older versions have no '{{ max }}' param
+        ], array_diff_key($violation->getParameters(), array_flip(['{{ max }}'])));
 
         self::assertSame(2, $violation->getPlural());
         self::assertSame($message, $violation->getRoot());
@@ -83,5 +92,61 @@ final class EmbeddedViolationListFormatterUnitTest extends TestCase
         self::assertSame(Length::TOO_LONG_ERROR, $violation->getCode());
         self::assertSame($constraint, $violation->getConstraint());
         self::assertNull($violation->getCause());
+    }
+
+    /**
+     * Validation::createCallable() eagerly translates with the server-default locale,
+     * so the formatter must re-translate to honour the request's Accept-Language.
+     */
+    public function testValidationFailedExceptionMessageIsRetranslated(): void
+    {
+        $message = HandleableMessageStub::create();
+
+        try {
+            Validation::createCallable(new Length(max: 3))('matched!');
+
+            self::fail('The exception must be thrown.');
+        } catch (ValidationFailedException $originalException) {
+        }
+
+        $violation = $this->matchOne($originalException, $message);
+
+        // Message is re-translated, as it's from Validation::class exception
+        self::assertSame(
+            're-translated [domain]: This value is too long. It should have 3 character or less.|This value is too long. It should have 3 characters or less. ',
+            $violation->getMessage(),
+        );
+        self::assertSame('matchedProperty', $violation->getPropertyPath());
+    }
+
+    public function testManuallyThrownValidationFailedExceptionIsNotRetranslated(): void
+    {
+        $message = HandleableMessageStub::create();
+
+        $violations = Validation::createValidator()->validate('matched!', [new Length(max: 3)]);
+        // Not thrown from Validation::createCallable(), so it's not re-translated
+        $originalException = new ValidationFailedException('matched!', $violations);
+
+        $violation = $this->matchOne($originalException, $message);
+
+        // The message is kept "as is":
+        self::assertSame(
+            'This value is too long. It should have 3 characters or less.',
+            $violation->getMessage(),
+        );
+        self::assertSame('matchedProperty', $violation->getPropertyPath());
+    }
+
+    private function matchOne(Throwable $originalException, HandleableMessageStub $message): ConstraintViolation
+    {
+        $violationList = $this->matcher->match($originalException, $message);
+
+        self::assertNotNull($violationList);
+        self::assertCount(1, $violationList);
+
+        $violation = $violationList[0];
+        self::assertInstanceOf(ConstraintViolation::class, $violation);
+
+        return $violation;
     }
 }

--- a/src/ExceptionalMatcher/Integration/Validator/Formatter/Embedded/ViolationsEmbeddedExceptionFormatter.php
+++ b/src/ExceptionalMatcher/Integration/Validator/Formatter/Embedded/ViolationsEmbeddedExceptionFormatter.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace PhPhD\ExceptionalMatcher\Integration\Validator\Formatter\Embedded;
 
+use Closure;
 use LogicException;
 use PhPhD\ExceptionalMatcher\Exception\MatchedException;
 use PhPhD\ExceptionalMatcher\Integration\Validator\Formatter\ExceptionViolationFormatter;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\Validator\Exception\ValidationFailedException;
+use Symfony\Component\Validator\Validation;
+use Throwable;
 use Webmozart\Assert\Assert;
 
 use function array_map;
@@ -25,6 +28,13 @@ const embedded_violations = ViolationsEmbeddedExceptionFormatter::class;
  */
 final class ViolationsEmbeddedExceptionFormatter implements ExceptionViolationFormatter
 {
+    /** @api */
+    public function __construct(
+        /** @var ?Closure(string,array<array-key,mixed>):string */
+        private readonly ?Closure $translate = null,
+    ) {
+    }
+
     /**
      * @param MatchedException<ViolationsEmbeddedException|ValidationFailedException> $matchedException
      *
@@ -35,11 +45,6 @@ final class ViolationsEmbeddedExceptionFormatter implements ExceptionViolationFo
         $exception = $matchedException->getException();
         Assert::isInstanceOfAny($exception, [ViolationsEmbeddedException::class, ValidationFailedException::class]);
 
-        $rule = $matchedException->getRule();
-        $root = $rule->getRootObject();
-        $propertyPath = $rule->getPropertyPath()
-            ->join('.')
-        ;
         /** @var list<ConstraintViolationInterface> $violationList */
         $violationList = iterator_to_array($exception->getViolations());
 
@@ -47,9 +52,20 @@ final class ViolationsEmbeddedExceptionFormatter implements ExceptionViolationFo
             throw new LogicException('Violation list must not be empty');
         }
 
+        $rule = $matchedException->getRule();
+
+        $root = $rule->getRootObject();
+        $propertyPath = $rule->getPropertyPath()
+            ->join('.')
+        ;
+        $redoTranslation = $this->shouldRedoTranslation($exception);
+
+        /** @psalm-suppress PossiblyNullFunctionCall */
         return array_map(
-            static fn (ConstraintViolationInterface $violation): ConstraintViolation => new ConstraintViolation(
-                $violation->getMessage(),
+            fn (ConstraintViolationInterface $violation): ConstraintViolation => new ConstraintViolation(
+                $redoTranslation
+                    ? ($this->translate)($violation->getMessageTemplate(), $violation->getParameters())
+                    : $violation->getMessage(),
                 $violation->getMessageTemplate(),
                 $violation->getParameters(),
                 $root,
@@ -62,5 +78,25 @@ final class ViolationsEmbeddedExceptionFormatter implements ExceptionViolationFo
             ),
             $violationList,
         );
+    }
+
+    /**
+     * Validation::createCallable() instantiates a validator afresh,
+     * so the pre-translated message does not reflect an Accept-Language header,
+     * thereby it requires re-translation.
+     *
+     * @phpstan-assert-if-true !null $this->translate
+     */
+    private function shouldRedoTranslation(Throwable $exception): bool
+    {
+        if (null === $this->translate) {
+            return false;
+        }
+
+        if (ValidationFailedException::class !== $exception::class) {
+            return false;
+        }
+
+        return Validation::class === ($exception->getTrace()[0]['class'] ?? null);
     }
 }

--- a/src/ExceptionalMatcher/Integration/Validator/Formatter/Embedded/services.php
+++ b/src/ExceptionalMatcher/Integration/Validator/Formatter/Embedded/services.php
@@ -7,7 +7,9 @@ namespace PhPhD\ExceptionalMatcher\Integration\Validator\Formatter\Embedded;
 use PhPhD\ExceptionalMatcher\Exception\Formatter\MatchedExceptionFormatter;
 use PhPhD\ExceptionalMatcher\Integration\Validator\Formatter\ExceptionViolationFormatter;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Validator\Exception\ValidationFailedException;
 
 return static function (ContainerConfigurator $configurator, ContainerBuilder $container): void {
@@ -19,6 +21,9 @@ return static function (ContainerConfigurator $configurator, ContainerBuilder $c
 
     $services
         ->set(ExceptionViolationFormatter::class.'<'.ViolationsEmbeddedException::class.'>', ViolationsEmbeddedExceptionFormatter::class)
+        ->args([
+            new Reference('phd_exceptional_matcher.translator', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),
+        ])
         ->tag(MatchedExceptionFormatter::class, ['id' => ViolationsEmbeddedExceptionFormatter::class])
     ;
 

--- a/src/ExceptionalMatcher/Integration/Validator/Formatter/Main/MainExceptionViolationFormatter.php
+++ b/src/ExceptionalMatcher/Integration/Validator/Formatter/Main/MainExceptionViolationFormatter.php
@@ -34,7 +34,10 @@ final class MainExceptionViolationFormatter implements ExceptionViolationFormatt
     /** @api */
     public static function translator(TranslatorInterface $translator, string $translationDomain): Closure
     {
-        return static fn (string $messageTemplate): string => $translator->trans($messageTemplate, domain: $translationDomain);
+        return static fn (
+            string $messageTemplate,
+            array $parameters = [],
+        ): string => $translator->trans($messageTemplate, $parameters, domain: $translationDomain);
     }
 
     /** @return array{ConstraintViolation} */


### PR DESCRIPTION
Closes https://github.com/phphd/exceptional-matcher/issues/101